### PR TITLE
feat: CoinListViewController 및 하위 뷰 기본 구현

### DIFF
--- a/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
+++ b/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
@@ -12,6 +12,11 @@
 		03D6C6BE27C91F620028A7E0 /* Coin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6C6BD27C91F620028A7E0 /* Coin.swift */; };
 		03E19BFD27C9297F00F36A46 /* CoinListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E19BFC27C9297F00F36A46 /* CoinListViewModel.swift */; };
 		03E19BFF27C9299D00F36A46 /* CoinListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E19BFE27C9299D00F36A46 /* CoinListViewController.swift */; };
+		03F2EC8427D059E800CEC21E /* CoinListButtonBarPagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8327D059E800CEC21E /* CoinListButtonBarPagerViewController.swift */; };
+		03F2EC8627D05AA600CEC21E /* KRWViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8527D05AA600CEC21E /* KRWViewController.swift */; };
+		03F2EC8827D05ABC00CEC21E /* FavoriteCoinViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8727D05ABC00CEC21E /* FavoriteCoinViewController.swift */; };
+		03F2EC8A27D05C1A00CEC21E /* PopularityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8927D05C1A00CEC21E /* PopularityViewController.swift */; };
+		03F2EC8C27D065EF00CEC21E /* UISearchBar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8B27D065EF00CEC21E /* UISearchBar+Extension.swift */; };
 		1C9CFDFA27C75FCB00647FCE /* WebSocketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9CFDF927C75FCB00647FCE /* WebSocketService.swift */; };
 		1C9CFE2727C7C85D00647FCE /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9CFE2627C7C85D00647FCE /* String+Extension.swift */; };
 		1C9CFE2A27C7C8F200647FCE /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9CFE2927C7C8F200647FCE /* NetworkError.swift */; };
@@ -35,10 +40,10 @@
 		E592A92727C67BA9008BE814 /* Candlestick.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A92627C67BA9008BE814 /* Candlestick.swift */; };
 		E592A92927C67D61008BE814 /* RealtimeOrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A92827C67D61008BE814 /* RealtimeOrderBook.swift */; };
 		E592A92B27C67E8C008BE814 /* RealtimeTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A92A27C67E8C008BE814 /* RealtimeTransaction.swift */; };
-		E592A93F27CA81E1008BE814 /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93E27CA81E1008BE814 /* OrderBook.swift */; };
-		E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94027CA8381008BE814 /* TransactionHistory.swift */; };
 		E592A93327C9340F008BE814 /* OrderBookViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93227C9340F008BE814 /* OrderBookViewController.swift */; };
 		E592A93727C94741008BE814 /* OrderBookCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93627C94741008BE814 /* OrderBookCell.swift */; };
+		E592A93F27CA81E1008BE814 /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93E27CA81E1008BE814 /* OrderBook.swift */; };
+		E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94027CA8381008BE814 /* TransactionHistory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +69,11 @@
 		03D6C6BD27C91F620028A7E0 /* Coin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coin.swift; sourceTree = "<group>"; };
 		03E19BFC27C9297F00F36A46 /* CoinListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewModel.swift; sourceTree = "<group>"; };
 		03E19BFE27C9299D00F36A46 /* CoinListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewController.swift; sourceTree = "<group>"; };
+		03F2EC8327D059E800CEC21E /* CoinListButtonBarPagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListButtonBarPagerViewController.swift; sourceTree = "<group>"; };
+		03F2EC8527D05AA600CEC21E /* KRWViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KRWViewController.swift; sourceTree = "<group>"; };
+		03F2EC8727D05ABC00CEC21E /* FavoriteCoinViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCoinViewController.swift; sourceTree = "<group>"; };
+		03F2EC8927D05C1A00CEC21E /* PopularityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularityViewController.swift; sourceTree = "<group>"; };
+		03F2EC8B27D065EF00CEC21E /* UISearchBar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchBar+Extension.swift"; sourceTree = "<group>"; };
 		18428F2A50A0AD57949D9ADA /* Pods_BithumbProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BithumbProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C9CFDF927C75FCB00647FCE /* WebSocketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketService.swift; sourceTree = "<group>"; };
 		1C9CFE2627C7C85D00647FCE /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
@@ -96,10 +106,10 @@
 		E592A92627C67BA9008BE814 /* Candlestick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Candlestick.swift; sourceTree = "<group>"; };
 		E592A92827C67D61008BE814 /* RealtimeOrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeOrderBook.swift; sourceTree = "<group>"; };
 		E592A92A27C67E8C008BE814 /* RealtimeTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTransaction.swift; sourceTree = "<group>"; };
-		E592A93E27CA81E1008BE814 /* OrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBook.swift; sourceTree = "<group>"; };
-		E592A94027CA8381008BE814 /* TransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistory.swift; sourceTree = "<group>"; };
 		E592A93227C9340F008BE814 /* OrderBookViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookViewController.swift; sourceTree = "<group>"; };
 		E592A93627C94741008BE814 /* OrderBookCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookCell.swift; sourceTree = "<group>"; };
+		E592A93E27CA81E1008BE814 /* OrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBook.swift; sourceTree = "<group>"; };
+		E592A94027CA8381008BE814 /* TransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistory.swift; sourceTree = "<group>"; };
 		ECEC5EB2399A967136BEEFBB /* Pods-BithumbProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-BithumbProjectTests/Pods-BithumbProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -143,6 +153,7 @@
 			isa = PBXGroup;
 			children = (
 				1C9CFE2627C7C85D00647FCE /* String+Extension.swift */,
+				03F2EC8B27D065EF00CEC21E /* UISearchBar+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -266,6 +277,10 @@
 			isa = PBXGroup;
 			children = (
 				03E19BFE27C9299D00F36A46 /* CoinListViewController.swift */,
+				03F2EC8327D059E800CEC21E /* CoinListButtonBarPagerViewController.swift */,
+				03F2EC8527D05AA600CEC21E /* KRWViewController.swift */,
+				03F2EC8927D05C1A00CEC21E /* PopularityViewController.swift */,
+				03F2EC8727D05ABC00CEC21E /* FavoriteCoinViewController.swift */,
 				E592A93227C9340F008BE814 /* OrderBookViewController.swift */,
 				E592A93627C94741008BE814 /* OrderBookCell.swift */,
 			);
@@ -598,6 +613,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1C9CFE2A27C7C8F200647FCE /* NetworkError.swift in Sources */,
+				03F2EC8627D05AA600CEC21E /* KRWViewController.swift in Sources */,
 				E592A93327C9340F008BE814 /* OrderBookViewController.swift in Sources */,
 				1C9CFE2727C7C85D00647FCE /* String+Extension.swift in Sources */,
 				E592A93727C94741008BE814 /* OrderBookCell.swift in Sources */,
@@ -613,12 +629,16 @@
 				1CDFFC8327C5266E0033B759 /* SceneDelegate.swift in Sources */,
 				1CDFFCBD27C533ED0033B759 /* ViewModelType.swift in Sources */,
 				E592A92127C678E3008BE814 /* AssetsStatus.swift in Sources */,
+				03F2EC8A27D05C1A00CEC21E /* PopularityViewController.swift in Sources */,
+				03F2EC8427D059E800CEC21E /* CoinListButtonBarPagerViewController.swift in Sources */,
 				1CDFFCBB27C52F7F0033B759 /* Constant.swift in Sources */,
 				03D6C6BB27C91DE70028A7E0 /* HTTPManager.swift in Sources */,
 				E592A91D27C67303008BE814 /* APIResponse.swift in Sources */,
+				03F2EC8827D05ABC00CEC21E /* FavoriteCoinViewController.swift in Sources */,
 				E592A92327C67984008BE814 /* RealtimeTicker.swift in Sources */,
 				1C9CFE2E27C7E0CC00647FCE /* WebSocketManager.swift in Sources */,
 				E592A92727C67BA9008BE814 /* Candlestick.swift in Sources */,
+				03F2EC8C27D065EF00CEC21E /* UISearchBar+Extension.swift in Sources */,
 				03E19BFD27C9297F00F36A46 /* CoinListViewModel.swift in Sources */,
 				E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */,
 			);

--- a/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
+++ b/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		03F2EC8827D05ABC00CEC21E /* FavoriteCoinViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8727D05ABC00CEC21E /* FavoriteCoinViewController.swift */; };
 		03F2EC8A27D05C1A00CEC21E /* PopularityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8927D05C1A00CEC21E /* PopularityViewController.swift */; };
 		03F2EC8C27D065EF00CEC21E /* UISearchBar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8B27D065EF00CEC21E /* UISearchBar+Extension.swift */; };
+		03F2EC8E27D0726E00CEC21E /* ChangeRateSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2EC8D27D0726E00CEC21E /* ChangeRateSettingViewController.swift */; };
 		1C9CFDFA27C75FCB00647FCE /* WebSocketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9CFDF927C75FCB00647FCE /* WebSocketService.swift */; };
 		1C9CFE2727C7C85D00647FCE /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9CFE2627C7C85D00647FCE /* String+Extension.swift */; };
 		1C9CFE2A27C7C8F200647FCE /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9CFE2927C7C8F200647FCE /* NetworkError.swift */; };
@@ -74,6 +75,7 @@
 		03F2EC8727D05ABC00CEC21E /* FavoriteCoinViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCoinViewController.swift; sourceTree = "<group>"; };
 		03F2EC8927D05C1A00CEC21E /* PopularityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularityViewController.swift; sourceTree = "<group>"; };
 		03F2EC8B27D065EF00CEC21E /* UISearchBar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchBar+Extension.swift"; sourceTree = "<group>"; };
+		03F2EC8D27D0726E00CEC21E /* ChangeRateSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeRateSettingViewController.swift; sourceTree = "<group>"; };
 		18428F2A50A0AD57949D9ADA /* Pods_BithumbProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BithumbProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C9CFDF927C75FCB00647FCE /* WebSocketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketService.swift; sourceTree = "<group>"; };
 		1C9CFE2627C7C85D00647FCE /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				03F2EC8527D05AA600CEC21E /* KRWViewController.swift */,
 				03F2EC8927D05C1A00CEC21E /* PopularityViewController.swift */,
 				03F2EC8727D05ABC00CEC21E /* FavoriteCoinViewController.swift */,
+				03F2EC8D27D0726E00CEC21E /* ChangeRateSettingViewController.swift */,
 				E592A93227C9340F008BE814 /* OrderBookViewController.swift */,
 				E592A93627C94741008BE814 /* OrderBookCell.swift */,
 			);
@@ -621,6 +624,7 @@
 				1C9CFDFA27C75FCB00647FCE /* WebSocketService.swift in Sources */,
 				03D6C6BE27C91F620028A7E0 /* Coin.swift in Sources */,
 				1CDFFC8127C5266E0033B759 /* AppDelegate.swift in Sources */,
+				03F2EC8E27D0726E00CEC21E /* ChangeRateSettingViewController.swift in Sources */,
 				E592A92B27C67E8C008BE814 /* RealtimeTransaction.swift in Sources */,
 				E592A92927C67D61008BE814 /* RealtimeOrderBook.swift in Sources */,
 				03D6C6BA27C91DE70028A7E0 /* HTTPService.swift in Sources */,

--- a/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
+++ b/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		1CDFFCA427C5266F0033B759 /* BithumbProjectUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDFFCA327C5266F0033B759 /* BithumbProjectUITestsLaunchTests.swift */; };
 		1CDFFCBB27C52F7F0033B759 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDFFCBA27C52F7F0033B759 /* Constant.swift */; };
 		1CDFFCBD27C533ED0033B759 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDFFCBC27C533ED0033B759 /* ViewModelType.swift */; };
+		249C3E7927D0A9250069E131 /* PeriodTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249C3E7827D0A9250069E131 /* PeriodTableViewCell.swift */; };
+		249C3E7B27D0ABDE0069E131 /* ChangeRateSettingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249C3E7A27D0ABDE0069E131 /* ChangeRateSettingHeaderView.swift */; };
 		2A92A7ECB0838843A92AC2AD /* Pods_BithumbProjectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18428F2A50A0AD57949D9ADA /* Pods_BithumbProjectTests.framework */; };
 		532B1ABC85F8AEA9FE9A0449 /* Pods_BithumbProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58A31623DBD441C2DF5D935B /* Pods_BithumbProject.framework */; };
 		7377C65BC5D4352A6E8ACB80 /* Pods_BithumbProject_BithumbProjectUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 248E52B21DD25FF26025A40A /* Pods_BithumbProject_BithumbProjectUITests.framework */; };
@@ -105,6 +107,8 @@
 		1CDFFCBA27C52F7F0033B759 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		1CDFFCBC27C533ED0033B759 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		248E52B21DD25FF26025A40A /* Pods_BithumbProject_BithumbProjectUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BithumbProject_BithumbProjectUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		249C3E7827D0A9250069E131 /* PeriodTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodTableViewCell.swift; sourceTree = "<group>"; };
+		249C3E7A27D0ABDE0069E131 /* ChangeRateSettingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeRateSettingHeaderView.swift; sourceTree = "<group>"; };
 		2C0DF3FC129104ABB573CD1B /* Pods-BithumbProjectTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbProjectTests.release.xcconfig"; path = "Target Support Files/Pods-BithumbProjectTests/Pods-BithumbProjectTests.release.xcconfig"; sourceTree = "<group>"; };
 		58A31623DBD441C2DF5D935B /* Pods_BithumbProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BithumbProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F5F699AD92EA317CFC92076 /* Pods-BithumbProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbProject.debug.xcconfig"; path = "Target Support Files/Pods-BithumbProject/Pods-BithumbProject.debug.xcconfig"; sourceTree = "<group>"; };
@@ -296,6 +300,8 @@
 				03F2EC8927D05C1A00CEC21E /* PopularityViewController.swift */,
 				03F2EC8727D05ABC00CEC21E /* FavoriteCoinViewController.swift */,
 				03F2EC8D27D0726E00CEC21E /* ChangeRateSettingViewController.swift */,
+				249C3E7A27D0ABDE0069E131 /* ChangeRateSettingHeaderView.swift */,
+				249C3E7827D0A9250069E131 /* PeriodTableViewCell.swift */,
 				1C33CF9827CF3618007E91F0 /* CoinDetailViewController.swift */,
 				1C33CF9E27CF7D84007E91F0 /* CoinDetailButtonBarPagerViewController.swift */,
 				1C33CFA027CF9F80007E91F0 /* ChartViewController.swift */,
@@ -634,6 +640,7 @@
 				03F2EC8627D05AA600CEC21E /* KRWViewController.swift in Sources */,
 				E592A93327C9340F008BE814 /* OrderBookViewController.swift in Sources */,
 				1C9CFE2727C7C85D00647FCE /* String+Extension.swift in Sources */,
+				249C3E7B27D0ABDE0069E131 /* ChangeRateSettingHeaderView.swift in Sources */,
 				E592A93727C94741008BE814 /* OrderBookCell.swift in Sources */,
 				03E19BFF27C9299D00F36A46 /* CoinListViewController.swift in Sources */,
 				1C9CFDFA27C75FCB00647FCE /* WebSocketService.swift in Sources */,
@@ -648,6 +655,7 @@
 				1CDFFC8327C5266E0033B759 /* SceneDelegate.swift in Sources */,
 				1CDFFCBD27C533ED0033B759 /* ViewModelType.swift in Sources */,
 				1C33CF9B27CF364F007E91F0 /* CoinDetailViewModel.swift in Sources */,
+				249C3E7927D0A9250069E131 /* PeriodTableViewCell.swift in Sources */,
 				E592A92127C678E3008BE814 /* AssetsStatus.swift in Sources */,
 				03F2EC8A27D05C1A00CEC21E /* PopularityViewController.swift in Sources */,
 				03F2EC8427D059E800CEC21E /* CoinListButtonBarPagerViewController.swift in Sources */,

--- a/BithumbProject/BithumbProject/Sources/Application/AppDelegate.swift
+++ b/BithumbProject/BithumbProject/Sources/Application/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/BithumbProject/BithumbProject/Sources/Application/AppDelegate.swift
+++ b/BithumbProject/BithumbProject/Sources/Application/AppDelegate.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
+++ b/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
         window?.backgroundColor = .white
-        window?.rootViewController = UINavigationController(rootViewController: CoinListViewController()) 
+        window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
     }
 }

--- a/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
+++ b/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
         window?.backgroundColor = .white
-        window?.rootViewController = ViewController()
+        window?.rootViewController = UINavigationController(rootViewController: CoinListViewController()) 
         window?.makeKeyAndVisible()
     }
 }

--- a/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
+++ b/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
@@ -12,11 +12,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        let tempRootViewModel = CoinListViewModel()
+        var tempRootView = CoinListViewController()
+        tempRootView.bind(viewModel: tempRootViewModel)
+        
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
         window?.backgroundColor = .white
-        window?.rootViewController = ViewController()
+        window?.rootViewController = UINavigationController(rootViewController: tempRootView)
         window?.makeKeyAndVisible()
     }
 }

--- a/BithumbProject/BithumbProject/Sources/Repositories/WebSocketManager.swift
+++ b/BithumbProject/BithumbProject/Sources/Repositories/WebSocketManager.swift
@@ -28,6 +28,7 @@ final class WebSocketManager: WebSocketService {
     
     private var disposeBag: DisposeBag = DisposeBag()
     
+    // swiftlint:disable all
     func requestRealtime<T: Codable>(
         parameter: [String: Any],
         type: T.Type
@@ -77,4 +78,5 @@ final class WebSocketManager: WebSocketService {
             return Disposables.create()
         }
     }
+    // swiftlint:enable all
 }

--- a/BithumbProject/BithumbProject/Sources/SupportingFiles/Extensions/UISearchBar+Extension.swift
+++ b/BithumbProject/BithumbProject/Sources/SupportingFiles/Extensions/UISearchBar+Extension.swift
@@ -1,0 +1,28 @@
+//
+//  UISearchBar+Extension.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import UIKit
+
+extension UISearchBar {
+    func addDoneButtonOnKeyboard() {
+        let doneToolbar: UIToolbar = UIToolbar(frame: CGRect.init(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
+        doneToolbar.barStyle = .default
+        
+        let flexSpaceItem = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let doneBarButton: UIBarButtonItem = UIBarButtonItem(title:  NSLocalizedString("닫기", comment: ""), style: .done, target: self, action: #selector(self.doneButtonAction))
+        
+        let items = [flexSpaceItem, doneBarButton]
+        doneToolbar.items = items
+        doneToolbar.sizeToFit()
+        
+        self.inputAccessoryView = doneToolbar
+    }
+    
+    @objc func doneButtonAction(){
+        self.resignFirstResponder()
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/SupportingFiles/Extensions/UISearchBar+Extension.swift
+++ b/BithumbProject/BithumbProject/Sources/SupportingFiles/Extensions/UISearchBar+Extension.swift
@@ -13,7 +13,7 @@ extension UISearchBar {
         doneToolbar.barStyle = .default
         
         let flexSpaceItem = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneBarButton: UIBarButtonItem = UIBarButtonItem(title:  NSLocalizedString("닫기", comment: ""), style: .done, target: self, action: #selector(self.doneButtonAction))
+        let doneBarButton: UIBarButtonItem = UIBarButtonItem(title: NSLocalizedString("닫기", comment: ""), style: .done, target: self, action: #selector(self.doneButtonAction))
         
         let items = [flexSpaceItem, doneBarButton]
         doneToolbar.items = items
@@ -22,7 +22,7 @@ extension UISearchBar {
         self.inputAccessoryView = doneToolbar
     }
     
-    @objc func doneButtonAction(){
+    @objc func doneButtonAction() {
         self.resignFirstResponder()
     }
 }

--- a/BithumbProject/BithumbProject/Sources/SupportingFiles/Extensions/UISearchBar+Extension.swift
+++ b/BithumbProject/BithumbProject/Sources/SupportingFiles/Extensions/UISearchBar+Extension.swift
@@ -9,11 +9,15 @@ import UIKit
 
 extension UISearchBar {
     func addDoneButtonOnKeyboard() {
-        let doneToolbar: UIToolbar = UIToolbar(frame: CGRect.init(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
+        let doneToolbar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
         doneToolbar.barStyle = .default
         
         let flexSpaceItem = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneBarButton: UIBarButtonItem = UIBarButtonItem(title: NSLocalizedString("닫기", comment: ""), style: .done, target: self, action: #selector(self.doneButtonAction))
+        let doneBarButton: UIBarButtonItem = UIBarButtonItem(
+            title: NSLocalizedString("닫기", comment: ""),
+            style: .done,
+            target: self,
+            action: #selector(self.doneButtonAction))
         
         let items = [flexSpaceItem, doneBarButton]
         doneToolbar.items = items

--- a/BithumbProject/BithumbProject/Sources/ViewModels/CoinListViewModel.swift
+++ b/BithumbProject/BithumbProject/Sources/ViewModels/CoinListViewModel.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+import RxCocoa
+import RxSwift
+
 final class CoinListViewModel: ViewModelType {
     
     struct Input {
@@ -14,7 +17,7 @@ final class CoinListViewModel: ViewModelType {
     }
     
     struct Output {
-        
+        let changeRates = BehaviorRelay<[ChangeRate]>(value: [])
     }
     
     var input: Input
@@ -23,6 +26,14 @@ final class CoinListViewModel: ViewModelType {
     init() {
         self.input = Input()
         self.output = Output()
+        
+        
+    }
+    
+    private initialChangeRates() -> Observable<[ChangeRate]> {
+        let chageRates = [
+            ChangeRate(time: .Day, isSelected: <#T##Bool#>)
+        ]
     }
     
 }

--- a/BithumbProject/BithumbProject/Sources/ViewModels/CoinListViewModel.swift
+++ b/BithumbProject/BithumbProject/Sources/ViewModels/CoinListViewModel.swift
@@ -7,6 +7,22 @@
 
 import Foundation
 
-final class CoinListViewModel {
+final class CoinListViewModel: ViewModelType {
+    
+    struct Input {
+        
+    }
+    
+    struct Output {
+        
+    }
+    
+    var input: Input
+    var output: Output
+    
+    init() {
+        self.input = Input()
+        self.output = Output()
+    }
     
 }

--- a/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingHeaderView.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingHeaderView.swift
@@ -1,0 +1,58 @@
+//
+//  ChangeRateSettingHeaderView.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ChangeRateSettingHeaderView: UIView {
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "변동률 기간 설정"
+        $0.font = UIFont.systemFont(ofSize: 25, weight: .semibold)
+    }
+    
+    private let descriptionLabel = UILabel().then {
+        $0.text = """
+        APP 내 데이터 기준 기간이 모두 동일하게 변경됩니다.
+        거래금액은 최근 24시간 기준으로 표기됩니다.
+        """
+        $0.font = UIFont.systemFont(ofSize: 15, weight: .light)
+        $0.textColor = .systemGray
+        $0.numberOfLines = 2
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.makeConstrains()
+        self.configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.makeConstrains()
+        self.configureUI()
+    }
+    
+    private func makeConstrains() {
+        self.addSubview(self.titleLabel)
+        self.addSubview(self.descriptionLabel)
+        self.titleLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().offset(30)
+        }
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(15)
+            make.leading.equalTo(self.titleLabel.snp.leading)
+            make.bottom.equalToSuperview()
+        }
+    }
+    
+    private func configureUI() {
+        self.backgroundColor = .systemBackground
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingViewController.swift
@@ -1,0 +1,17 @@
+//
+//  ChangeRateSettingViewController.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import UIKit
+
+class ChangeRateSettingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemPink
+    }
+
+}

--- a/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingViewController.swift
@@ -8,28 +8,117 @@
 import UIKit
 
 import PanModal
+import RxCocoa
+import RxDataSources
+import RxSwift
+import SnapKit
+import Then
 
-class ChangeRateSettingViewController: UIViewController {
+class ChangeRateSettingViewController: UIViewController, ViewModelBindable {
+    
+    private let dismissButton = UIButton().then {
+        let image = UIImage(
+            systemName: "xmark",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 20))
+        $0.setImage(image, for: .normal)
+        $0.tintColor = .darkGray
+    }
+    
+    private let periodHeaderView = ChangeRateSettingHeaderView(frame: .zero)
+    
+    private let periodTableView = UITableView().then {
+        $0.register(PeriodTableViewCell.self,
+                    forCellReuseIdentifier: PeriodTableViewCell.identifier)
+    }
+    
+    var viewModel: CoinListViewModel!
+    var disposeBag: DisposeBag = DisposeBag()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .systemPink
+        self.makeConstraints()
+        self.configureUI()
+    }
+    
+    func bindViewModel() {
+        
+        Observable.from([])
+            .bind(to: self.periodTableView.rx.items(dataSource: createDataSource()))
+            .disposed(by: self.disposeBag)
+        
+        //        self.periodTableView.rx.modelSelected(ChangeRate.self)
+        
+        self.dismissButton.rx.tap
+            .withUnretained(self)
+            .bind(onNext: { owner, _ in
+                owner.dismiss(animated: true, completion: nil)
+            })
+            .disposed(by: self.disposeBag)
+        
+        self.periodTableView.rx.setDelegate(self)
+            .disposed(by: self.disposeBag)
+    }
+    
+    typealias PeriodDataSource = RxTableViewSectionedReloadDataSource<SectionModel<Int, ChangeRate>>
+    private func createDataSource() -> PeriodDataSource {
+        return PeriodDataSource { datasource, tableView, indexPath, item in
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: PeriodTableViewCell.identifier,
+                for: indexPath) as? PeriodTableViewCell else {
+                    return UITableViewCell()
+                }
+            cell.rendering(item)
+            return cell
+        }
+    }
+    
+    private func makeConstraints() {
+        self.view.addSubview(self.periodTableView)
+        self.view.addSubview(self.dismissButton)
+        self.periodTableView.snp.makeConstraints { make in
+            make.top.leading.bottom.trailing.equalToSuperview()
+        }
+        self.dismissButton.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(30)
+            make.trailing.equalToSuperview().inset(30)
+        }
+    }
+    
+    private func configureUI() {
+        self.view.backgroundColor = .systemBackground
     }
 
 }
 
 extension ChangeRateSettingViewController: PanModalPresentable {
-
     var panScrollable: UIScrollView? {
         return nil
     }
     
     var shortFormHeight: PanModalHeight {
-        return .contentHeight(300)
+        return .contentHeight(400)
     }
+}
 
-    var longFormHeight: PanModalHeight {
-        return .maxHeightWithTopInset(40)
+extension ChangeRateSettingViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return self.periodHeaderView
     }
     
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 200
+    }
+}
+
+struct ChangeRate {
+    enum Period {
+        case MID
+        case Day
+        case HalfDay
+        case Hour
+        case HalfHour
+    }
+    
+    let time: Period
+    let isSelected: Bool = false
 }

--- a/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/ChangeRateSettingViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import PanModal
+
 class ChangeRateSettingViewController: UIViewController {
 
     override func viewDidLoad() {
@@ -14,4 +16,20 @@ class ChangeRateSettingViewController: UIViewController {
         self.view.backgroundColor = .systemPink
     }
 
+}
+
+extension ChangeRateSettingViewController: PanModalPresentable {
+
+    var panScrollable: UIScrollView? {
+        return nil
+    }
+    
+    var shortFormHeight: PanModalHeight {
+        return .contentHeight(300)
+    }
+
+    var longFormHeight: PanModalHeight {
+        return .maxHeightWithTopInset(40)
+    }
+    
 }

--- a/BithumbProject/BithumbProject/Sources/Views/CoinListButtonBarPagerViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/CoinListButtonBarPagerViewController.swift
@@ -9,10 +9,13 @@ import Foundation
 
 import Then
 import XLPagerTabStrip
+import RxSwift
+import RxCocoa
+import PanModal
 
-final class CoinListButtonBarPagerViewController: ButtonBarPagerTabStripViewController {
+final class CoinListButtonBarPagerViewController: ButtonBarPagerTabStripViewController, ViewModelBindable {
 
-    // MARK: -View Properties
+    // MARK: - View Properties
     private let scrollView: UIScrollView = UIScrollView()
     
     private let buttonBarPagerView: ButtonBarView = ButtonBarView(
@@ -31,6 +34,9 @@ final class CoinListButtonBarPagerViewController: ButtonBarPagerTabStripViewCont
         $0.tintColor = .gray
     }
     
+    var viewModel: CoinListViewModel!
+    var disposeBag: DisposeBag = DisposeBag()
+    
     override func viewDidLoad() {
         self.setupViews()
         self.configureStrip()
@@ -39,6 +45,16 @@ final class CoinListButtonBarPagerViewController: ButtonBarPagerTabStripViewCont
     
     override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
         return [KRWViewController(), PopularityViewController(), FavoriteCoinViewController()]
+    }
+    
+    func bindViewModel() {
+        self.changeRateSettingButton.rx.tap
+            .bind(onNext: {
+                let changeRateViewController = ChangeRateSettingViewController()
+                self.presentPanModal(changeRateViewController)
+            })
+            .disposed(by: disposeBag)
+        
     }
     
     private func setupViews() {

--- a/BithumbProject/BithumbProject/Sources/Views/CoinListButtonBarPagerViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/CoinListButtonBarPagerViewController.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
+import PanModal
+import RxCocoa
+import RxSwift
 import Then
 import XLPagerTabStrip
-import RxSwift
-import RxCocoa
-import PanModal
 
 final class CoinListButtonBarPagerViewController: ButtonBarPagerTabStripViewController, ViewModelBindable {
 

--- a/BithumbProject/BithumbProject/Sources/Views/CoinListButtonBarPagerViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/CoinListButtonBarPagerViewController.swift
@@ -1,0 +1,122 @@
+//
+//  CoinListButtonBarPagerViewController.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import Foundation
+
+import Then
+import XLPagerTabStrip
+
+final class CoinListButtonBarPagerViewController: ButtonBarPagerTabStripViewController {
+
+    // MARK: -View Properties
+    private let scrollView: UIScrollView = UIScrollView()
+    
+    private let buttonBarPagerView: ButtonBarView = ButtonBarView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout()
+    )
+    
+    private let changeRateSettingButton = UIButton().then {
+        $0.setTitle("1시간", for: .normal)
+        $0.setTitleColor(.gray, for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .light)
+    }
+    
+    private let changeRateSettingImage = UIImageView().then {
+        $0.image = UIImage(systemName: "chevron.down", withConfiguration: UIImage.SymbolConfiguration.init(pointSize: 14))
+        $0.tintColor = .gray
+    }
+    
+    override func viewDidLoad() {
+        self.setupViews()
+        self.configureStrip()
+        super.viewDidLoad()
+    }
+    
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+        return [KRWViewController(), PopularityViewController(), FavoriteCoinViewController()]
+    }
+    
+    private func setupViews() {
+        
+        let changeRateStackView = UIStackView(arrangedSubviews: [
+            self.changeRateSettingButton,
+            self.changeRateSettingImage]
+        ).then {
+            $0.distribution = .fill
+            $0.spacing = 2
+            $0.alignment = .center
+            $0.axis = .horizontal
+        }
+        
+        self.view.addSubview(changeRateStackView)
+        self.view.addSubview(self.buttonBarPagerView)
+        self.view.addSubview(self.scrollView)
+        
+        self.buttonBarPagerView.snp.makeConstraints { make in
+            make.height.equalTo(40)
+            make.width.equalTo(200)
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading)
+        }
+        
+        changeRateStackView.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            make.bottom.equalTo(self.buttonBarPagerView.snp.bottom)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing).inset(20)
+        }
+    
+        self.scrollView.snp.makeConstraints { make in
+            make.top.equalTo(buttonBarPagerView.snp.bottom)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+        }
+    }
+    
+    private func configureStrip() {
+        self.settings.style.buttonBarBackgroundColor = .white
+        self.settings.style.buttonBarItemBackgroundColor = .white
+        self.settings.style.selectedBarBackgroundColor = .black
+        self.settings.style.buttonBarItemFont = Font.defaultFont
+        self.settings.style.selectedBarHeight = 3
+        self.settings.style.buttonBarMinimumLineSpacing = 0
+        self.settings.style.buttonBarItemTitleColor = Font.defaultTextColor
+        self.settings.style.buttonBarItemsShouldFillAvailableWidth = true
+        self.settings.style.buttonBarLeftContentInset = 20
+        self.settings.style.buttonBarRightContentInset = 20
+        
+        // swiftlint:disable all
+        self.changeCurrentIndexProgressive = {(
+            oldCell: ButtonBarViewCell?,
+            newCell: ButtonBarViewCell?,
+            progressPercentage: CGFloat,
+            changeCurrentIndex: Bool,
+            animated: Bool) -> Void in
+            guard changeCurrentIndex == true else {
+                return
+            }
+            oldCell?.label.font = Font.defaultFont
+            oldCell?.label.textColor = Font.defaultTextColor
+            newCell?.label.font = Font.selectedFont
+            newCell?.label.textColor = Font.selectedTextColor
+        }
+        // swiftlint:enable all
+        
+        self.buttonBarView = self.buttonBarPagerView
+        self.containerView = self.scrollView
+    }
+}
+
+extension CoinListButtonBarPagerViewController {
+    enum Font {
+        fileprivate static let defaultFont: UIFont = .systemFont(ofSize: 17, weight: .semibold)
+        fileprivate static let defaultTextColor: UIColor = .systemGray
+        fileprivate static let selectedFont: UIFont = .systemFont(ofSize: 17, weight: .semibold)
+        fileprivate static let selectedTextColor: UIColor = .black
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/CoinListViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/CoinListViewController.swift
@@ -34,7 +34,7 @@ class CoinListViewController: UIViewController, ViewModelBindable {
         $0.tintColor = .black
     }
     
-    private let coinListButtonBarPagerViewController: ButtonBarPagerTabStripViewController = CoinListButtonBarPagerViewController()
+    private var coinListButtonBarPagerViewController = CoinListButtonBarPagerViewController()
     
     var viewModel: CoinListViewModel!
     var disposeBag: DisposeBag = DisposeBag()
@@ -51,6 +51,7 @@ class CoinListViewController: UIViewController, ViewModelBindable {
     }
     
     private func setupViews() {
+        self.coinListButtonBarPagerViewController.bind(viewModel: self.viewModel)
         self.view.addSubview(self.coinListButtonBarPagerViewController.view)
         self.coinListButtonBarPagerViewController.view.snp.makeConstraints {
             $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)

--- a/BithumbProject/BithumbProject/Sources/Views/CoinListViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/CoinListViewController.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
 import SnapKit
 import Then
-import RxSwift
-import RxCocoa
 import XLPagerTabStrip
 
 class CoinListViewController: UIViewController, ViewModelBindable {

--- a/BithumbProject/BithumbProject/Sources/Views/CoinListViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/CoinListViewController.swift
@@ -7,23 +7,62 @@
 
 import UIKit
 
-class CoinListViewController: UIViewController {
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
+import XLPagerTabStrip
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+class CoinListViewController: UIViewController, ViewModelBindable {
+    
+    // MARK: - View Properties
+    private lazy var coinSearchBar = UISearchBar().then {
+        $0.placeholder = "코인명 또는 심볼 검색"
+        $0.keyboardType = .webSearch
+        $0.searchTextField.backgroundColor = .systemBackground
+        $0.addDoneButtonOnKeyboard()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+#warning("Constant 관리 및 다크모드 대응 Color 제작 필요")
+    private let cafeBarButton = UIBarButtonItem().then {
+        $0.image = UIImage(systemName: "gift")
+        $0.tintColor = .black
     }
-    */
-
+    
+    private let alarmBarButton = UIBarButtonItem().then {
+        $0.image = UIImage(systemName: "bell")
+        $0.tintColor = .black
+    }
+    
+    private let coinListButtonBarPagerViewController: ButtonBarPagerTabStripViewController = CoinListButtonBarPagerViewController()
+    
+    var viewModel: CoinListViewModel!
+    var disposeBag: DisposeBag = DisposeBag()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setupViews()
+        self.setupNavigation()
+    }
+    
+    // MARK: - CoinListViewController Bind
+    func bindViewModel() {
+        
+    }
+    
+    private func setupViews() {
+        self.view.addSubview(self.coinListButtonBarPagerViewController.view)
+        self.coinListButtonBarPagerViewController.view.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            $0.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading)
+            $0.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+        }
+    }
+    
+    private func setupNavigation() {
+        self.navigationItem.hidesSearchBarWhenScrolling = false
+        self.navigationItem.titleView = self.coinSearchBar
+        self.navigationItem.rightBarButtonItems = [self.cafeBarButton, self.alarmBarButton]
+    }
 }

--- a/BithumbProject/BithumbProject/Sources/Views/FavoriteCoinViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/FavoriteCoinViewController.swift
@@ -1,0 +1,24 @@
+//
+//  FavoriteCoinViewController.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import UIKit
+
+import XLPagerTabStrip
+
+class FavoriteCoinViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemGreen
+    }
+}
+
+extension FavoriteCoinViewController: IndicatorInfoProvider {
+    func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        IndicatorInfo(title: "관심")
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/KRWViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/KRWViewController.swift
@@ -1,0 +1,23 @@
+//
+//  KRWViewController.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import UIKit
+import XLPagerTabStrip
+
+class KRWViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemRed
+    }
+}
+
+extension KRWViewController: IndicatorInfoProvider {
+    func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        IndicatorInfo(title: "원화")
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/KRWViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/KRWViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+
 import XLPagerTabStrip
 
 class KRWViewController: UIViewController {

--- a/BithumbProject/BithumbProject/Sources/Views/PeriodTableViewCell.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/PeriodTableViewCell.swift
@@ -1,0 +1,59 @@
+//
+//  PeriodTableViewCell.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+class PeriodTableViewCell: UITableViewCell {
+    static let identifier = "PeriodTableViewCell"
+    
+    private let periodLabel = UILabel().then {
+        $0.text = "어제대비"
+        $0.font = UIFont.systemFont(ofSize: 20, weight: .light)
+        $0.textColor = .black
+    }
+    
+    private let checkImage = UIImageView().then {
+        $0.image = UIImage(systemName: "checkmark", withConfiguration: UIImage.SymbolConfiguration.init(pointSize: 20))
+        $0.tintColor = .systemRed
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.makeConstrains()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.makeConstrains()
+    }
+    
+    private func makeConstrains() {
+        self.contentView.addSubview(self.periodLabel)
+        self.contentView.addSubview(self.checkImage)
+        
+        self.periodLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().offset(20)
+        }
+        
+        self.checkImage.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(20)
+        }
+    }
+}
+
+extension PeriodTableViewCell {
+    func rendering(_ changeRate: ChangeRate) {
+        
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/PopularityViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/PopularityViewController.swift
@@ -15,18 +15,6 @@ class PopularityViewController: UIViewController {
         super.viewDidLoad()
         self.view.backgroundColor = .systemBlue
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }
 
 extension PopularityViewController: IndicatorInfoProvider {

--- a/BithumbProject/BithumbProject/Sources/Views/PopularityViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/PopularityViewController.swift
@@ -1,0 +1,36 @@
+//
+//  PopularityViewController.swift
+//  BithumbProject
+//
+//  Created by 박형석 on 2022/03/03.
+//
+
+import UIKit
+
+import XLPagerTabStrip
+
+class PopularityViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemBlue
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}
+
+extension PopularityViewController: IndicatorInfoProvider {
+    func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        IndicatorInfo(title: "인기")
+    }
+}

--- a/BithumbProject/Podfile
+++ b/BithumbProject/Podfile
@@ -23,6 +23,7 @@ target 'BithumbProject' do
   pod 'Charts'
   pod 'SpreadsheetView'
   pod 'XLPagerTabStrip'
+  pod 'PanModal'
 
   target 'BithumbProjectTests' do
     inherit! :search_paths

--- a/BithumbProject/Podfile.lock
+++ b/BithumbProject/Podfile.lock
@@ -8,6 +8,7 @@ PODS:
     - Moya/Core (= 15.0.0)
   - Moya/Core (15.0.0):
     - Alamofire (~> 5.0)
+  - PanModal (1.2.7)
   - RxCocoa (6.5.0):
     - RxRelay (= 6.5.0)
     - RxSwift (= 6.5.0)
@@ -42,6 +43,7 @@ PODS:
 DEPENDENCIES:
   - Charts
   - Moya
+  - PanModal
   - RxCocoa
   - RxDataSources
   - RxGesture
@@ -63,6 +65,7 @@ SPEC REPOS:
     - Charts
     - Differentiator
     - Moya
+    - PanModal
     - RxCocoa
     - RxDataSources
     - RxGesture
@@ -84,6 +87,7 @@ SPEC CHECKSUMS:
   Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
   Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
+  PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
   RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
   RxGesture: abadd243fc36db74df43dfc893829ddde94f1a3d
@@ -100,6 +104,6 @@ SPEC CHECKSUMS:
   Then: acfe0be7e98221c6204e12f8161459606d5d822d
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
 
-PODFILE CHECKSUM: 33a326bdd5d8f0a8cbfbf2446fa830d55e4605ff
+PODFILE CHECKSUM: b1e3505fcc3b30da505471b34a44426844ebf68b
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
### Description
- 메인이 될 CoinListViewController를 제작하고 sceneDelegte에 임시로 rootViewController로 설정해 놓았습니다.
- XLPagerTabStrip을 적용할 기본 ViewController 바탕을 구현해 놓았습니다.
- PanModal pod을 설치하고 ChangeRateSettingViewController에 적용했습니다.

### 구현 이미지
|First Image|Second Image|
|:-:|:-:|
|![First Image](https://user-images.githubusercontent.com/77890228/156494983-99ad7924-1398-4daf-b069-f735b4bc147f.png)|![Second Image](https://user-images.githubusercontent.com/77890228/156495022-fb1693f9-d021-41a3-8c20-7f7cdefb1381.png)|

### Related Issue
#17