### PR TITLE
feat : OrderBookViewController 구현

### DIFF
--- a/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
+++ b/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
@@ -35,11 +35,12 @@
 		E592A92727C67BA9008BE814 /* Candlestick.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A92627C67BA9008BE814 /* Candlestick.swift */; };
 		E592A92927C67D61008BE814 /* RealtimeOrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A92827C67D61008BE814 /* RealtimeOrderBook.swift */; };
 		E592A92B27C67E8C008BE814 /* RealtimeTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A92A27C67E8C008BE814 /* RealtimeTransaction.swift */; };
-		E592A93F27CA81E1008BE814 /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93E27CA81E1008BE814 /* OrderBook.swift */; };
-		E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94027CA8381008BE814 /* TransactionHistory.swift */; };
 		E592A93327C9340F008BE814 /* OrderBookViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93227C9340F008BE814 /* OrderBookViewController.swift */; };
 		E592A93727C94741008BE814 /* OrderBookCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93627C94741008BE814 /* OrderBookCell.swift */; };
 		E592A93D27CA1FE8008BE814 /* OrderBookViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93C27CA1FE8008BE814 /* OrderBookViewModel.swift */; };
+		E592A93F27CA81E1008BE814 /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93E27CA81E1008BE814 /* OrderBook.swift */; };
+		E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94027CA8381008BE814 /* TransactionHistory.swift */; };
+		E592A94A27CE791E008BE814 /* OrderBookTickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94927CE791E008BE814 /* OrderBookTickerCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,11 +98,12 @@
 		E592A92627C67BA9008BE814 /* Candlestick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Candlestick.swift; sourceTree = "<group>"; };
 		E592A92827C67D61008BE814 /* RealtimeOrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeOrderBook.swift; sourceTree = "<group>"; };
 		E592A92A27C67E8C008BE814 /* RealtimeTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTransaction.swift; sourceTree = "<group>"; };
-		E592A93E27CA81E1008BE814 /* OrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBook.swift; sourceTree = "<group>"; };
-		E592A94027CA8381008BE814 /* TransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistory.swift; sourceTree = "<group>"; };
 		E592A93227C9340F008BE814 /* OrderBookViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookViewController.swift; sourceTree = "<group>"; };
 		E592A93627C94741008BE814 /* OrderBookCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookCell.swift; sourceTree = "<group>"; };
 		E592A93C27CA1FE8008BE814 /* OrderBookViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookViewModel.swift; sourceTree = "<group>"; };
+		E592A93E27CA81E1008BE814 /* OrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBook.swift; sourceTree = "<group>"; };
+		E592A94027CA8381008BE814 /* TransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistory.swift; sourceTree = "<group>"; };
+		E592A94927CE791E008BE814 /* OrderBookTickerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookTickerCell.swift; sourceTree = "<group>"; };
 		ECEC5EB2399A967136BEEFBB /* Pods-BithumbProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-BithumbProjectTests/Pods-BithumbProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -271,6 +273,7 @@
 				03E19BFE27C9299D00F36A46 /* CoinListViewController.swift */,
 				E592A93227C9340F008BE814 /* OrderBookViewController.swift */,
 				E592A93627C94741008BE814 /* OrderBookCell.swift */,
+				E592A94927CE791E008BE814 /* OrderBookTickerCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -605,6 +608,7 @@
 				1C9CFE2727C7C85D00647FCE /* String+Extension.swift in Sources */,
 				E592A93727C94741008BE814 /* OrderBookCell.swift in Sources */,
 				03E19BFF27C9299D00F36A46 /* CoinListViewController.swift in Sources */,
+				E592A94A27CE791E008BE814 /* OrderBookTickerCell.swift in Sources */,
 				1C9CFDFA27C75FCB00647FCE /* WebSocketService.swift in Sources */,
 				03D6C6BE27C91F620028A7E0 /* Coin.swift in Sources */,
 				1CDFFC8127C5266E0033B759 /* AppDelegate.swift in Sources */,

--- a/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
+++ b/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		E592A92B27C67E8C008BE814 /* RealtimeTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A92A27C67E8C008BE814 /* RealtimeTransaction.swift */; };
 		E592A93327C9340F008BE814 /* OrderBookViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93227C9340F008BE814 /* OrderBookViewController.swift */; };
 		E592A93727C94741008BE814 /* OrderBookCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93627C94741008BE814 /* OrderBookCell.swift */; };
+		E592A93D27CA1FE8008BE814 /* OrderBookViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93C27CA1FE8008BE814 /* OrderBookViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +97,7 @@
 		E592A92A27C67E8C008BE814 /* RealtimeTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTransaction.swift; sourceTree = "<group>"; };
 		E592A93227C9340F008BE814 /* OrderBookViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookViewController.swift; sourceTree = "<group>"; };
 		E592A93627C94741008BE814 /* OrderBookCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookCell.swift; sourceTree = "<group>"; };
+		E592A93C27CA1FE8008BE814 /* OrderBookViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookViewModel.swift; sourceTree = "<group>"; };
 		ECEC5EB2399A967136BEEFBB /* Pods-BithumbProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-BithumbProjectTests/Pods-BithumbProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -131,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				03E19BFC27C9297F00F36A46 /* CoinListViewModel.swift */,
+				E592A93C27CA1FE8008BE814 /* OrderBookViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -599,6 +602,7 @@
 				1C9CFDFA27C75FCB00647FCE /* WebSocketService.swift in Sources */,
 				03D6C6BE27C91F620028A7E0 /* Coin.swift in Sources */,
 				1CDFFC8127C5266E0033B759 /* AppDelegate.swift in Sources */,
+				E592A93D27CA1FE8008BE814 /* OrderBookViewModel.swift in Sources */,
 				E592A92B27C67E8C008BE814 /* RealtimeTransaction.swift in Sources */,
 				E592A92927C67D61008BE814 /* RealtimeOrderBook.swift in Sources */,
 				03D6C6BA27C91DE70028A7E0 /* HTTPService.swift in Sources */,

--- a/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
+++ b/BithumbProject/BithumbProject.xcodeproj/project.pbxproj
@@ -54,8 +54,10 @@
 		E592A93F27CA81E1008BE814 /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93E27CA81E1008BE814 /* OrderBook.swift */; };
 		E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94027CA8381008BE814 /* TransactionHistory.swift */; };
 		E592A94A27CE791E008BE814 /* OrderBookTickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94927CE791E008BE814 /* OrderBookTickerCell.swift */; };
-		E592A93F27CA81E1008BE814 /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A93E27CA81E1008BE814 /* OrderBook.swift */; };
-		E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A94027CA8381008BE814 /* TransactionHistory.swift */; };
+		E592A95D27D10E08008BE814 /* OrderBookTransactionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A95C27D10E08008BE814 /* OrderBookTransactionCell.swift */; };
+		E592A95F27D124D0008BE814 /* TransactionCellViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A95E27D124D0008BE814 /* TransactionCellViewController.swift */; };
+		E592A96127D129D4008BE814 /* TransactionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A96027D129D4008BE814 /* TransactionCellViewModel.swift */; };
+		E592A96327D335AE008BE814 /* TransactionSmallCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A96227D335AE008BE814 /* TransactionSmallCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -132,8 +134,10 @@
 		E592A93E27CA81E1008BE814 /* OrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBook.swift; sourceTree = "<group>"; };
 		E592A94027CA8381008BE814 /* TransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistory.swift; sourceTree = "<group>"; };
 		E592A94927CE791E008BE814 /* OrderBookTickerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookTickerCell.swift; sourceTree = "<group>"; };
-		E592A93E27CA81E1008BE814 /* OrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBook.swift; sourceTree = "<group>"; };
-		E592A94027CA8381008BE814 /* TransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistory.swift; sourceTree = "<group>"; };
+		E592A95C27D10E08008BE814 /* OrderBookTransactionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookTransactionCell.swift; sourceTree = "<group>"; };
+		E592A95E27D124D0008BE814 /* TransactionCellViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionCellViewController.swift; sourceTree = "<group>"; };
+		E592A96027D129D4008BE814 /* TransactionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionCellViewModel.swift; sourceTree = "<group>"; };
+		E592A96227D335AE008BE814 /* TransactionSmallCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSmallCell.swift; sourceTree = "<group>"; };
 		ECEC5EB2399A967136BEEFBB /* Pods-BithumbProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-BithumbProjectTests/Pods-BithumbProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -171,6 +175,7 @@
 				03E19BFC27C9297F00F36A46 /* CoinListViewModel.swift */,
 				E592A93C27CA1FE8008BE814 /* OrderBookViewModel.swift */,
 				1C33CF9A27CF364F007E91F0 /* CoinDetailViewModel.swift */,
+				E592A96027D129D4008BE814 /* TransactionCellViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -317,6 +322,9 @@
 				E592A93227C9340F008BE814 /* OrderBookViewController.swift */,
 				E592A93627C94741008BE814 /* OrderBookCell.swift */,
 				E592A94927CE791E008BE814 /* OrderBookTickerCell.swift */,
+				E592A95C27D10E08008BE814 /* OrderBookTransactionCell.swift */,
+				E592A95E27D124D0008BE814 /* TransactionCellViewController.swift */,
+				E592A96227D335AE008BE814 /* TransactionSmallCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -647,11 +655,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				1C9CFE2A27C7C8F200647FCE /* NetworkError.swift in Sources */,
+				E592A96127D129D4008BE814 /* TransactionCellViewModel.swift in Sources */,
 				03F2EC8627D05AA600CEC21E /* KRWViewController.swift in Sources */,
 				E592A93327C9340F008BE814 /* OrderBookViewController.swift in Sources */,
 				1C9CFE2727C7C85D00647FCE /* String+Extension.swift in Sources */,
 				249C3E7B27D0ABDE0069E131 /* ChangeRateSettingHeaderView.swift in Sources */,
 				E592A93727C94741008BE814 /* OrderBookCell.swift in Sources */,
+				E592A95D27D10E08008BE814 /* OrderBookTransactionCell.swift in Sources */,
 				03E19BFF27C9299D00F36A46 /* CoinListViewController.swift in Sources */,
 				E592A94A27CE791E008BE814 /* OrderBookTickerCell.swift in Sources */,
 				1C9CFDFA27C75FCB00647FCE /* WebSocketService.swift in Sources */,
@@ -675,6 +685,7 @@
 				1CDFFCBB27C52F7F0033B759 /* Constant.swift in Sources */,
 				03D6C6BB27C91DE70028A7E0 /* HTTPManager.swift in Sources */,
 				1C33CF9D27CF4C0F007E91F0 /* Double+Extension.swift in Sources */,
+				E592A96327D335AE008BE814 /* TransactionSmallCell.swift in Sources */,
 				1C33CF9F27CF7D84007E91F0 /* CoinDetailButtonBarPagerViewController.swift in Sources */,
 				1C33CFA127CF9F80007E91F0 /* ChartViewController.swift in Sources */,
 				E592A91D27C67303008BE814 /* APIResponse.swift in Sources */,
@@ -682,6 +693,7 @@
 				E592A92327C67984008BE814 /* RealtimeTicker.swift in Sources */,
 				1C9CFE2E27C7E0CC00647FCE /* WebSocketManager.swift in Sources */,
 				E592A92727C67BA9008BE814 /* Candlestick.swift in Sources */,
+				E592A95F27D124D0008BE814 /* TransactionCellViewController.swift in Sources */,
 				03F2EC8C27D065EF00CEC21E /* UISearchBar+Extension.swift in Sources */,
 				03E19BFD27C9297F00F36A46 /* CoinListViewModel.swift in Sources */,
 				E592A94127CA8381008BE814 /* TransactionHistory.swift in Sources */,

--- a/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
+++ b/BithumbProject/BithumbProject/Sources/Application/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
         window?.backgroundColor = .white
-        window?.rootViewController = ViewController()
+        window?.rootViewController = OrderBookViewController()
         window?.makeKeyAndVisible()
     }
 }

--- a/BithumbProject/BithumbProject/Sources/Models/TransactionHistory.swift
+++ b/BithumbProject/BithumbProject/Sources/Models/TransactionHistory.swift
@@ -13,6 +13,7 @@ struct TransactionHistory: Codable {
     var unitsTraded: String?
     var price: String?
     var total: String?
+    var updown: String?
     
     enum CodingKeys: String, CodingKey {
         case transactionDate = "transaction_date"
@@ -20,5 +21,6 @@ struct TransactionHistory: Codable {
         case unitsTraded = "units_traded"
         case price
         case total
+        case updown
     }
 }

--- a/BithumbProject/BithumbProject/Sources/Repositories/HTTPService.swift
+++ b/BithumbProject/BithumbProject/Sources/Repositories/HTTPService.swift
@@ -15,6 +15,7 @@ enum HTTPService {
     case ticker(_ orderCurrency: OrderCurrency)
     case assetsStatus(_ orderCurrency: OrderCurrency = "All")
     case candleStick(_ orderCurrency: OrderCurrency, _ chartIntervals: String)
+    case orderBook(_ orderCurrency: OrderCurrency)
 }
 
 extension HTTPService: TargetType {
@@ -30,6 +31,8 @@ extension HTTPService: TargetType {
             return Constant.Path.assetsStatusPath + "/\(orderCurrency)"
         case .candleStick(let orderCurrency, let chartIntervals):
             return Constant.Path.candleStickPath + "/\(orderCurrency)" + "/\(chartIntervals)"
+        case .orderBook(let orderCurrency):
+            return Constant.Path.orderBookPath + "/\(orderCurrency)"
         }
     }
     

--- a/BithumbProject/BithumbProject/Sources/Repositories/HTTPService.swift
+++ b/BithumbProject/BithumbProject/Sources/Repositories/HTTPService.swift
@@ -16,6 +16,7 @@ enum HTTPService {
     case assetsStatus(_ orderCurrency: OrderCurrency = "All")
     case candleStick(_ orderCurrency: OrderCurrency, _ chartIntervals: String)
     case orderBook(_ orderCurrency: OrderCurrency)
+    case transactionHistory(_ orderCurrency: OrderCurrency)
 }
 
 extension HTTPService: TargetType {
@@ -33,6 +34,8 @@ extension HTTPService: TargetType {
             return Constant.Path.candleStickPath + "/\(orderCurrency)" + "/\(chartIntervals)"
         case .orderBook(let orderCurrency):
             return Constant.Path.orderBookPath + "/\(orderCurrency)"
+        case .transactionHistory(let orderCurrency):
+            return Constant.Path.transationHistoryPath + "/\(orderCurrency)"
         }
     }
     

--- a/BithumbProject/BithumbProject/Sources/SupportingFiles/Constants/Constant.swift
+++ b/BithumbProject/BithumbProject/Sources/SupportingFiles/Constants/Constant.swift
@@ -54,5 +54,6 @@ enum Constant {
         static let tickerPath = "/ticker"
         static let assetsStatusPath = "/assetsstatus"
         static let candleStickPath = "/candlestick"
+        static let orderBookPath = "/orderbook"
     }
 }

--- a/BithumbProject/BithumbProject/Sources/SupportingFiles/Constants/Constant.swift
+++ b/BithumbProject/BithumbProject/Sources/SupportingFiles/Constants/Constant.swift
@@ -55,5 +55,6 @@ enum Constant {
         static let assetsStatusPath = "/assetsstatus"
         static let candleStickPath = "/candlestick"
         static let orderBookPath = "/orderbook"
+        static let transationHistoryPath = "/transaction_history"
     }
 }

--- a/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
+++ b/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import RxSwift
 import RxCocoa
+import Moya
 
 final class OrderBookViewModel: ViewModelType {
 
@@ -16,19 +17,94 @@ final class OrderBookViewModel: ViewModelType {
     var disposeBag: DisposeBag = DisposeBag()
 
     struct Input {
-        let dummyData = PublishRelay<[RealtimeOrderBook]>()
+        let orderBookData = PublishRelay<OrderBook>()
+        let bidList = PublishRelay<[BidAsk]>()
+        let askList = PublishRelay<[BidAsk]>()
+        let realtimeOrderBookData = PublishRelay<RealtimeOrderBook>()
     }
     
     struct Output {
-        let dummyData = BehaviorRelay<[RealtimeOrderBook]>(value: [RealtimeOrderBook]())
+        let orderBookData = BehaviorRelay<OrderBook>(value: OrderBook())
+        let bidList = BehaviorRelay<[BidAsk]>(value: [])
+        let askList = BehaviorRelay<[BidAsk]>(value: [])
+        let realtimeOrderBookData = BehaviorRelay<RealtimeOrderBook>(value: RealtimeOrderBook())
     }
     
     init() {
         self.input = Input()
         self.output = Output()
         
-        self.input.dummyData
-            .bind(to: self.output.dummyData)
+        let provider = MoyaProvider<HTTPService>()
+        let httpManager = HTTPManager(provider: provider)
+        let webSocketManager = WebSocketManager()
+        
+        input.orderBookData
+            .bind(to: output.orderBookData)
             .disposed(by: disposeBag)
+        
+        input.bidList
+            .bind(to: output.bidList)
+            .disposed(by: disposeBag)
+        
+        input.askList
+            .bind(to: output.askList)
+            .disposed(by: disposeBag)
+        
+        input.realtimeOrderBookData
+            .bind(to: output.realtimeOrderBookData)
+            .disposed(by: disposeBag)
+        
+        httpManager.request(httpServiceType: .orderBook("BTC"), model: OrderBook.self)
+            .bind(to: input.orderBookData)
+            .disposed(by: disposeBag)
+        
+        output.orderBookData
+            .map { $0.bids ?? [] }
+            .map { $0.sorted { $0.price ?? "" > $1.price ?? "" } }
+            .bind(to: input.bidList)
+            .disposed(by: disposeBag)
+        
+        output.orderBookData
+            .map { $0.asks ?? [] }
+            .map { $0.sorted { $0.price ?? "" > $1.price ?? "" } }
+            .bind(to: input.askList)
+            .disposed(by: disposeBag)
+        
+        webSocketManager.requestRealtimeOrderbook()
+            .bind(to: input.realtimeOrderBookData)
+            .disposed(by: disposeBag)
+        
+        output.realtimeOrderBookData
+            .map { $0.list?.filter { $0.orderType == "bid" } ?? [] }
+            .withUnretained(output.bidList) {( $0, $1 )}
+            .map { self.reflectRealtimeData(previousList: $0.value, realtimeList: $1) }
+            .map { $0.sorted { $0.price ?? "" > $1.price ?? "" }}
+            .bind(to: input.bidList)
+            .disposed(by: disposeBag)
+        
+        output.realtimeOrderBookData
+            .map { $0.list?.filter { $0.orderType == "ask" } ?? [] }
+            .withUnretained(output.askList) {( $0, $1 )}
+            .map { self.reflectRealtimeData(previousList: $0.value, realtimeList: $1) }
+            .map { $0.sorted { $0.price ?? "" > $1.price ?? "" }}
+            .bind(to: input.askList)
+            .disposed(by: disposeBag)
+    }
+    
+    private func reflectRealtimeData(previousList: [BidAsk], realtimeList: [RealtimeOrderbookDepth]) -> [BidAsk] {
+        var changedList = previousList
+        realtimeList.forEach { realtimeItem in
+            if let index = changedList.firstIndex(where: { $0.price == realtimeItem.price }) {
+                if realtimeItem.quantity == "0" {
+                    changedList.remove(at: index)
+                } else {
+                    changedList[index].price = realtimeItem.price
+                    changedList[index].quantity = realtimeItem.quantity
+                }
+            } else {
+                changedList.append(BidAsk(quantity: realtimeItem.quantity, price: realtimeItem.price))
+            }
+        }
+        return changedList
     }
 }

--- a/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
+++ b/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  OrderBookViewModel.swift
+//  BithumbProject
+//
+//  Created by 최다빈 on 2022/02/26.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class OrderBookViewModel: ViewModelType {
+
+    var input: Input
+    var output: Output
+    var disposeBag: DisposeBag = DisposeBag()
+
+    struct Input {
+        let dummyData = PublishRelay<[RealtimeOrderBook]>()
+    }
+    
+    struct Output {
+        let dummyData = BehaviorRelay<[RealtimeOrderBook]>(value: [RealtimeOrderBook]())
+    }
+    
+    init() {
+        self.input = Input()
+        self.output = Output()
+        
+        self.input.dummyData
+            .bind(to: self.output.dummyData)
+            .disposed(by: disposeBag)
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
+++ b/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
@@ -21,6 +21,7 @@ final class OrderBookViewModel: ViewModelType {
         let bidList = PublishRelay<[BidAsk]>()
         let askList = PublishRelay<[BidAsk]>()
         let realtimeOrderBookData = PublishRelay<RealtimeOrderBook>()
+        let tickerData = PublishRelay<Ticker>()
     }
     
     struct Output {
@@ -28,6 +29,7 @@ final class OrderBookViewModel: ViewModelType {
         let bidList = BehaviorRelay<[BidAsk]>(value: [])
         let askList = BehaviorRelay<[BidAsk]>(value: [])
         let realtimeOrderBookData = BehaviorRelay<RealtimeOrderBook>(value: RealtimeOrderBook())
+        let tickerData = BehaviorRelay<Ticker>(value: Ticker())
     }
     
     init() {
@@ -52,6 +54,10 @@ final class OrderBookViewModel: ViewModelType {
         
         input.realtimeOrderBookData
             .bind(to: output.realtimeOrderBookData)
+            .disposed(by: disposeBag)
+        
+        input.tickerData
+            .bind(to: output.tickerData)
             .disposed(by: disposeBag)
         
         httpManager.request(httpServiceType: .orderBook("BTC"), model: OrderBook.self)
@@ -88,6 +94,10 @@ final class OrderBookViewModel: ViewModelType {
             .map { self.reflectRealtimeData(previousList: $0.value, realtimeList: $1) }
             .map { $0.sorted { $0.price ?? "" > $1.price ?? "" }}
             .bind(to: input.askList)
+            .disposed(by: disposeBag)
+        
+        httpManager.request(httpServiceType: .ticker("BTC"), model: Ticker.self)
+            .bind(to: input.tickerData)
             .disposed(by: disposeBag)
     }
     

--- a/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
+++ b/BithumbProject/BithumbProject/Sources/ViewModels/OrderBookViewModel.swift
@@ -40,6 +40,11 @@ final class OrderBookViewModel: ViewModelType {
         let httpManager = HTTPManager(provider: provider)
         let webSocketManager = WebSocketManager()
         
+        let orderBookParameter: [String: Any] = [
+              "type": BithumbWebSocketRequestType.orderBookDepth.rawValue,
+              "symbols": ["BTC_KRW"]
+            ]
+        
         input.orderBookData
             .bind(to: output.orderBookData)
             .disposed(by: disposeBag)
@@ -75,8 +80,8 @@ final class OrderBookViewModel: ViewModelType {
             .map { $0.sorted { $0.price ?? "" > $1.price ?? "" } }
             .bind(to: input.askList)
             .disposed(by: disposeBag)
-        
-        webSocketManager.requestRealtimeOrderbook()
+
+        webSocketManager.requestRealtime(parameter: orderBookParameter, type: RealtimeOrderBook.self)
             .bind(to: input.realtimeOrderBookData)
             .disposed(by: disposeBag)
         

--- a/BithumbProject/BithumbProject/Sources/ViewModels/TransactionCellViewModel.swift
+++ b/BithumbProject/BithumbProject/Sources/ViewModels/TransactionCellViewModel.swift
@@ -1,0 +1,73 @@
+//
+//  TransactionCellViewModel.swift
+//  BithumbProject
+//
+//  Created by 최다빈 on 2022/03/04.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+import Moya
+
+final class TransactionCellViewModel: ViewModelType {
+    
+    var input: Input
+    var output: Output
+    var disposeBag: DisposeBag = DisposeBag()
+
+    struct Input {
+        let transactionData = PublishRelay<[TransactionHistory]>()
+        let realtimeTransationData = PublishRelay<RealtimeTransaction>()
+    }
+    
+    struct Output {
+        let transactionData = BehaviorRelay<[TransactionHistory]>(value: [])
+        let realtimeTransationData = BehaviorRelay<RealtimeTransaction>(value: RealtimeTransaction())
+    }
+    
+    init() {
+        self.input = Input()
+        self.output = Output()
+        
+        let provider = MoyaProvider<HTTPService>()
+        let httpManager = HTTPManager(provider: provider)
+        let webSocketManager = WebSocketManager()
+        
+        let transactionParameter: [String: Any] = [
+               "type": BithumbWebSocketRequestType.transaction.rawValue,
+               "symbols": ["BTC_KRW"]
+            ]
+
+        httpManager.request(httpServiceType: .transactionHistory("BTC"), model: [TransactionHistory].self)
+            .bind(to: input.transactionData)
+            .disposed(by: disposeBag)
+        
+        input.transactionData
+            .bind(to: output.transactionData)
+            .disposed(by: disposeBag)
+        
+        webSocketManager.requestRealtime(parameter: transactionParameter, type: RealtimeTransaction.self)
+            .bind(to: input.realtimeTransationData)
+            .disposed(by: disposeBag)
+        
+        input.realtimeTransationData
+            .withLatestFrom(input.transactionData) {( $0, $1 )}
+            .map { self.updateTransationData(realtimeList: $0.0.list, previousList: $0.1) }
+            .bind(to: input.transactionData)
+            .disposed(by: disposeBag)
+    }
+    
+    private func updateTransationData(realtimeList: [RealtimeTransactionItem]?, previousList: [TransactionHistory]) -> [TransactionHistory] {
+        var updatedList = previousList
+        realtimeList?.forEach {
+            var transaction = TransactionHistory()
+            transaction.price = $0.contractPrice
+            transaction.unitsTraded = $0.contractQuantity
+            transaction.updown = $0.updown
+            transaction.transactionDate = $0.contractDatetime
+            updatedList.append(transaction)
+        }
+        return updatedList
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/OrderBookCell.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/OrderBookCell.swift
@@ -17,6 +17,12 @@ class OrderBookCell: Cell {
         $0.font = UIFont.systemFont(ofSize: 12, weight: .medium)
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        contentView.backgroundColor = .white
+        self.label.text = ""
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         

--- a/BithumbProject/BithumbProject/Sources/Views/OrderBookTickerCell.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/OrderBookTickerCell.swift
@@ -1,0 +1,190 @@
+//
+//  OrderBookTickerCell.swift
+//  BithumbProject
+//
+//  Created by 최다빈 on 2022/03/02.
+//
+
+import Foundation
+import SpreadsheetView
+import Then
+import SnapKit
+import UIKit
+
+class OrderBookTickerCell: Cell {
+    
+    let lowPriceLabel = LeftTitleLabel().then {
+        $0.title = "저가(1H)"
+        $0.content("", color: .blue)
+    }
+    
+    let highPriceLabel = LeftTitleLabel().then {
+        $0.title = "고가(1H)"
+        $0.content("", color: .red)
+    }
+    
+    let openPriceLabel = LeftTitleLabel().then {
+        $0.title = "시가(1H)"
+    }
+    
+    let prevClosePriceLabel = LeftTitleLabel().then {
+        $0.title = "전일종가"
+    }
+    
+    let separateView = UIView().then {
+        $0.backgroundColor = .lightGray
+    }
+    
+    let accTradeValueLabel = LeftTitleLabel().then {
+        $0.title = "거래금"
+    }
+    
+    let unitsTradedLabel = LeftTitleLabel().then {
+        $0.title = "거래량"
+    }
+    
+    let accTradeValue24HLabel = LeftTitleLabel().then {
+        $0.title = "전일거래금"
+    }
+    
+    let unitsTraded24HLabel = LeftTitleLabel().then {
+        $0.title = "전일거래량"
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        contentView.backgroundColor = .white
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.addSubview(lowPriceLabel)
+        lowPriceLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(contentView).offset(-5)
+        }
+        
+        contentView.addSubview(highPriceLabel)
+        highPriceLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(lowPriceLabel.snp.top).offset(-5)
+        }
+        
+        contentView.addSubview(openPriceLabel)
+        openPriceLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(highPriceLabel.snp.top).offset(-5)
+        }
+        
+        contentView.addSubview(prevClosePriceLabel)
+        prevClosePriceLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(openPriceLabel.snp.top).offset(-5)
+        }
+        
+        contentView.addSubview(separateView)
+        separateView.snp.makeConstraints {
+            $0.leading.equalTo(contentView).offset(5)
+            $0.trailing.equalTo(contentView).offset(-5)
+            $0.bottom.equalTo(prevClosePriceLabel.snp.top).offset(-5)
+            $0.height.equalTo(1)
+        }
+        
+        contentView.addSubview(accTradeValueLabel)
+        accTradeValueLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(separateView.snp.top).offset(-5)
+        }
+
+        contentView.addSubview(unitsTradedLabel)
+        unitsTradedLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(accTradeValueLabel.snp.top).offset(-5)
+        }
+
+        contentView.addSubview(accTradeValue24HLabel)
+        accTradeValue24HLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(unitsTradedLabel.snp.top).offset(-5)
+        }
+
+        contentView.addSubview(unitsTraded24HLabel)
+        unitsTraded24HLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView)
+            $0.trailing.equalTo(contentView)
+            $0.bottom.equalTo(accTradeValue24HLabel.snp.top).offset(-5)
+        }
+        
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+final class LeftTitleLabel: UIView {
+    public var title: String? {
+        get { return titleLabel.text }
+        set { titleLabel.text = newValue }
+    }
+    
+    public var content: String? {
+        get { return contentLabel.text }
+        set { contentLabel.text = newValue }
+    }
+    
+    public func content(_ text: String, color: UIColor) {
+        self.contentLabel.text = text
+        self.contentLabel.textColor = color
+        self.contentLabel.textAlignment = .right
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 12, weight: .light)
+        $0.textColor = .lightGray
+        $0.textAlignment = .left
+    }
+    private let contentLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 12, weight: .light)
+        $0.textColor = .lightGray
+        $0.numberOfLines = 0
+        $0.textAlignment = .right
+    }
+
+    convenience init() {
+        self.init(frame: .zero)
+        
+        self.addSubview(titleLabel)
+        titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(self)
+            $0.leading.equalTo(self).offset(1)
+        }
+        
+        self.addSubview(contentLabel)
+        contentLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        contentLabel.snp.makeConstraints {
+            $0.top.equalTo(self)
+            $0.leading.equalTo(titleLabel.snp.trailing)
+            $0.trailing.equalTo(self).offset(-5)
+            $0.bottom.equalTo(self)
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/BithumbProject/BithumbProject/Sources/Views/OrderBookTransactionCell.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/OrderBookTransactionCell.swift
@@ -1,0 +1,26 @@
+//
+//  OrderBookTransactionCell.swift
+//  BithumbProject
+//
+//  Created by 최다빈 on 2022/03/03.
+//
+
+import Foundation
+import SpreadsheetView
+import Then
+import SnapKit
+
+class OrderBookTransactionCell: Cell {
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/OrderBookViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/OrderBookViewController.swift
@@ -9,10 +9,11 @@ import Foundation
 import UIKit
 import RxSwift
 import SpreadsheetView
+import RxDataSources
 
 class OrderBookViewController: UIViewController {
     var disposeBag = DisposeBag()
-//    let viewModel = OrderBookViewModel()
+    let viewModel = OrderBookViewModel()
 //    let baseView = OrderBookView()
     
     let spreadSheetView = SpreadsheetView()
@@ -32,6 +33,10 @@ class OrderBookViewController: UIViewController {
         spreadSheetView.snp.makeConstraints {
             $0.edges.equalTo(view.safeAreaLayoutGuide).inset(UIEdgeInsets.zero)
         }
+        
+        self.viewModel.output.dummyData
+            
+        
     }
 }
 

--- a/BithumbProject/BithumbProject/Sources/Views/OrderBookViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/OrderBookViewController.swift
@@ -17,6 +17,8 @@ class OrderBookViewController: UIViewController {
 //    let baseView = OrderBookView()
     
     let spreadSheetView = SpreadsheetView()
+    var bidList: [BidAsk] = []  // 매수
+    var askList: [BidAsk] = []  // 매도
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,9 +36,20 @@ class OrderBookViewController: UIViewController {
             $0.edges.equalTo(view.safeAreaLayoutGuide).inset(UIEdgeInsets.zero)
         }
         
-        self.viewModel.output.dummyData
-            
+        self.viewModel.output.bidList
+            .subscribe(onNext: { bidList in
+                self.bidList = bidList
+                self.spreadSheetView.reloadData()
+            })
+            .disposed(by: disposeBag)
         
+        self.viewModel.output.askList
+            .subscribe(onNext: { askList in
+                self.askList = askList
+                self.spreadSheetView.reloadData()
+            })
+            .disposed(by: disposeBag)
+            
     }
 }
 
@@ -71,31 +84,31 @@ extension OrderBookViewController: SpreadsheetViewDataSource {
     
     func spreadsheetView(_ spreadsheetView: SpreadsheetView, cellForItemAt indexPath: IndexPath) -> Cell? {
         let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: OrderBookCell.self), for: indexPath) as? OrderBookCell
-        
-        if indexPath.column ==  0 && indexPath.row < 30 {
-            cell?.label.text = "0.12345"
-            cell?.label.textAlignment = .right
-            cell?.contentView.backgroundColor = .blue
-        }
-        
-        if indexPath.column ==  1 {
-            if indexPath.row < 30 {
-                cell?.label.text = "45,678,912"
-                cell?.label.textAlignment = .center
+        if !self.askList.isEmpty && !self.bidList.isEmpty {
+            if indexPath.column ==  0 && indexPath.row < 30 {
+                cell?.label.text = self.askList[indexPath.row].quantity
+                cell?.label.textAlignment = .right
                 cell?.contentView.backgroundColor = .blue
-            } else {
-                cell?.label.text = "45,678,912"
-                cell?.label.textAlignment = .center
+            }
+            
+            if indexPath.column ==  1 {
+                if indexPath.row < 30 {
+                    cell?.label.text = self.askList[indexPath.row].price
+                    cell?.label.textAlignment = .center
+                    cell?.contentView.backgroundColor = .blue
+                } else {
+                    cell?.label.text = self.bidList[indexPath.row-30].price
+                    cell?.label.textAlignment = .center
+                    cell?.contentView.backgroundColor = .red
+                }
+            }
+            
+            if indexPath.column ==  2 && indexPath.row >= 30 {
+                cell?.label.text = self.bidList[indexPath.row-30].quantity
+                cell?.label.textAlignment = .left
                 cell?.contentView.backgroundColor = .red
             }
         }
-        
-        if indexPath.column ==  2 && indexPath.row >= 30 {
-            cell?.label.text = "0.12345"
-            cell?.label.textAlignment = .left
-            cell?.contentView.backgroundColor = .red
-        }
-        
         return cell
     }
 }

--- a/BithumbProject/BithumbProject/Sources/Views/OrderBookViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/OrderBookViewController.swift
@@ -14,7 +14,7 @@ import RxDataSources
 class OrderBookViewController: UIViewController {
     var disposeBag = DisposeBag()
     let viewModel = OrderBookViewModel()
-//    let baseView = OrderBookView()
+    let transactionCellViewController = TransactionCellViewController()
     
     let spreadSheetView = SpreadsheetView()
     var bidList: [BidAsk] = []  // 매수
@@ -32,6 +32,7 @@ class OrderBookViewController: UIViewController {
         
         self.spreadSheetView.register(OrderBookCell.self, forCellWithReuseIdentifier: String(describing: OrderBookCell.self))
         self.spreadSheetView.register(OrderBookTickerCell.self, forCellWithReuseIdentifier: String(describing: OrderBookTickerCell.self))
+        self.spreadSheetView.register(OrderBookTransactionCell.self, forCellWithReuseIdentifier: String(describing: OrderBookTransactionCell.self))
         
         view.addSubview(self.spreadSheetView)
         spreadSheetView.snp.makeConstraints {
@@ -58,7 +59,6 @@ class OrderBookViewController: UIViewController {
                 self.spreadSheetView.reloadData()
             })
             .disposed(by: disposeBag)
-            
     }
 }
 
@@ -103,33 +103,42 @@ extension OrderBookViewController: SpreadsheetViewDataSource {
             cell?.accTradeValue24HLabel.content = self.tickerData.accTradeValue24H
             cell?.unitsTraded24HLabel.content = self.tickerData.unitsTraded24H
             return cell
-        }
-        let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: OrderBookCell.self), for: indexPath) as? OrderBookCell
-        if !self.askList.isEmpty && !self.bidList.isEmpty {
-            if indexPath.column ==  0 && indexPath.row < 30 {
-                cell?.label.text = self.askList[indexPath.row].quantity
-                cell?.label.textAlignment = .right
-                cell?.contentView.backgroundColor = .blue
+        } else if indexPath.row == 30 && indexPath.column == 0 {
+            let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: OrderBookTransactionCell.self), for: indexPath)
+            cell.layoutIfNeeded()
+            if self.children.isEmpty {
+                transactionCellViewController.setup(to: self)
             }
-            
-            if indexPath.column ==  1 {
-                if indexPath.row < 30 {
-                    cell?.label.text = self.askList[indexPath.row].price
-                    cell?.label.textAlignment = .center
+            transactionCellViewController.attach(to: cell.contentView)
+            return cell
+        } else {
+            let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: OrderBookCell.self), for: indexPath) as? OrderBookCell
+            if !self.askList.isEmpty && !self.bidList.isEmpty {
+                if indexPath.column ==  0 && indexPath.row < 30 {
+                    cell?.label.text = self.askList[indexPath.row].quantity
+                    cell?.label.textAlignment = .right
                     cell?.contentView.backgroundColor = .blue
-                } else {
-                    cell?.label.text = self.bidList[indexPath.row-30].price
-                    cell?.label.textAlignment = .center
+                }
+                
+                if indexPath.column ==  1 {
+                    if indexPath.row < 30 {
+                        cell?.label.text = self.askList[indexPath.row].price
+                        cell?.label.textAlignment = .center
+                        cell?.contentView.backgroundColor = .blue
+                    } else {
+                        cell?.label.text = self.bidList[indexPath.row-30].price
+                        cell?.label.textAlignment = .center
+                        cell?.contentView.backgroundColor = .red
+                    }
+                }
+                
+                if indexPath.column ==  2 && indexPath.row >= 30 {
+                    cell?.label.text = self.bidList[indexPath.row-30].quantity
+                    cell?.label.textAlignment = .left
                     cell?.contentView.backgroundColor = .red
                 }
             }
-            
-            if indexPath.column ==  2 && indexPath.row >= 30 {
-                cell?.label.text = self.bidList[indexPath.row-30].quantity
-                cell?.label.textAlignment = .left
-                cell?.contentView.backgroundColor = .red
-            }
+            return cell
         }
-        return cell
     }
 }

--- a/BithumbProject/BithumbProject/Sources/Views/TransactionCellViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/TransactionCellViewController.swift
@@ -54,12 +54,14 @@ class TransactionCellViewController: UIViewController {
     private func bindViewModel() {
         viewModel.output.transactionData
             .map { $0.sorted { $0.transactionDate ?? "" > $1.transactionDate ?? "" }}
-            .map { $0[0..<20] }
-            .bind(to: self.tableView.rx.items(cellIdentifier: String(describing: TransactionSmallCell.self), cellType: TransactionSmallCell.self)) { (_, dataSource, cell) in
+            .map { [TransactionHistory(unitsTraded: "체결량", price: "체결가")] + $0[0..<20] }
+            .bind(to: self.tableView.rx.items(cellIdentifier: String(describing: TransactionSmallCell.self), cellType: TransactionSmallCell.self)) { (row, dataSource, cell) in
                 cell.contractPriceLabel.text = dataSource.price
                 cell.contractQuantityLabel.text = dataSource.unitsTraded
-                cell.contractPriceLabel.textColor = dataSource.updown == "dn" ? .blue : .red
-                cell.contractQuantityLabel.textColor = dataSource.updown == "dn" ? .blue : .red
+                if row != 0 {
+                    cell.contractPriceLabel.textColor = dataSource.updown == "dn" ? .blue : .red
+                    cell.contractQuantityLabel.textColor = dataSource.updown == "dn" ? .blue : .red
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/BithumbProject/BithumbProject/Sources/Views/TransactionCellViewController.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/TransactionCellViewController.swift
@@ -1,0 +1,66 @@
+//
+//  TransactionCellViewController.swift
+//  BithumbProject
+//
+//  Created by 최다빈 on 2022/03/04.
+//
+
+import Foundation
+import UIKit
+import RxSwift
+import RxDataSources
+
+class TransactionCellViewController: UIViewController {
+    let disposeBag = DisposeBag()
+    let viewModel = TransactionCellViewModel()
+    
+    let tableView = UITableView().then {
+        $0.separatorStyle = .none
+        $0.separatorInset = .zero
+        $0.register(TransactionSmallCell.self, forCellReuseIdentifier: String(describing: TransactionSmallCell.self))
+        $0.rowHeight = 20
+        $0.backgroundColor = .white
+        $0.isScrollEnabled = false
+        $0.allowsSelection = false
+    }
+ 
+    override func willMove(toParent parent: UIViewController?) {
+        super.willMove(toParent: parent)
+        bindViewModel()
+    }
+    
+    func setup(to target: UIViewController) {
+        target.addChild(self)
+        self.didMove(toParent: target)
+    }
+    
+    func attach(to view: UIView) {
+        self.view.backgroundColor = .green
+        
+        view.addSubview(self.view)
+        self.view.snp.makeConstraints {
+            $0.edges.equalTo(view)
+        }
+        
+        self.view.addSubview(self.tableView)
+        self.tableView.snp.makeConstraints {
+            $0.top.equalTo(self.view)
+            $0.leading.equalTo(self.view)
+            $0.trailing.equalTo(self.view)
+            $0.bottom.equalTo(self.view)
+        }
+    }
+    
+    private func bindViewModel() {
+        viewModel.output.transactionData
+            .map { $0.sorted { $0.transactionDate ?? "" > $1.transactionDate ?? "" }}
+            .map { $0[0..<20] }
+            .bind(to: self.tableView.rx.items(cellIdentifier: String(describing: TransactionSmallCell.self), cellType: TransactionSmallCell.self)) { (_, dataSource, cell) in
+                cell.contractPriceLabel.text = dataSource.price
+                cell.contractQuantityLabel.text = dataSource.unitsTraded
+                cell.contractPriceLabel.textColor = dataSource.updown == "dn" ? .blue : .red
+                cell.contractQuantityLabel.textColor = dataSource.updown == "dn" ? .blue : .red
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/TransactionSmallCell.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/TransactionSmallCell.swift
@@ -1,0 +1,59 @@
+//
+//  TransactionSmallCell.swift
+//  BithumbProject
+//
+//  Created by 최다빈 on 2022/03/05.
+//
+
+import Foundation
+import SpreadsheetView
+import Then
+import SnapKit
+
+class TransactionSmallCell: UITableViewCell {
+    static let identifier = "TransactionSmallCell"
+    
+    let contractPriceLabel = UILabel().then {
+        $0.text = "체결가격"
+        $0.font = UIFont.systemFont(ofSize: 12, weight: .light)
+        $0.textColor = .black
+        $0.textAlignment = .left
+    }
+    
+    let contractQuantityLabel = UILabel().then {
+        $0.text = "체결수량"
+        $0.font = UIFont.systemFont(ofSize: 12, weight: .light)
+        $0.textColor = .black
+        $0.textAlignment = .right
+    }
+    
+    private func makeConstrains() {
+        let contractStackView = UIStackView(
+            arrangedSubviews: [
+                self.contractPriceLabel,
+                self.contractQuantityLabel
+            ])
+            .then {
+                $0.axis = .horizontal
+                $0.alignment = .leading
+                $0.distribution = .fill
+                $0.spacing = 10
+            }
+        
+        self.contentView.addSubview(contractStackView)
+        contractStackView.snp.makeConstraints {
+            $0.leading.equalTo(self.contentView).offset(5)
+            $0.centerY.equalTo(self.contentView)
+            $0.trailing.equalTo(self.contentView).offset(-5)
+        }
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.makeConstrains()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/BithumbProject/BithumbProject/Sources/Views/TransactionSmallCell.swift
+++ b/BithumbProject/BithumbProject/Sources/Views/TransactionSmallCell.swift
@@ -27,6 +27,12 @@ class TransactionSmallCell: UITableViewCell {
         $0.textAlignment = .right
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.contractPriceLabel.textColor = .black
+        self.contractQuantityLabel.textColor = .black
+    }
+    
     private func makeConstrains() {
         let contractStackView = UIStackView(
             arrangedSubviews: [
@@ -42,9 +48,9 @@ class TransactionSmallCell: UITableViewCell {
         
         self.contentView.addSubview(contractStackView)
         contractStackView.snp.makeConstraints {
-            $0.leading.equalTo(self.contentView).offset(5)
+            $0.leading.equalTo(self.contentView).offset(3)
             $0.centerY.equalTo(self.contentView)
-            $0.trailing.equalTo(self.contentView).offset(-5)
+            $0.trailing.equalTo(self.contentView).offset(-3)
         }
     }
     


### PR DESCRIPTION
### Desciption
- OrderBook RestAPI와 WebsocketAPI를 사용하여 실시간 데이터를 보여주도록 구현하였습니다.
- SpreadSheetView의 (0,2) cell에 Ticker API를 사용하여 데이터를 보여주도록 구현하였습니다.
- SpreadSheetView의 (30,0) cell에 TransactionViewController를 추가하였습니다.
- TransactionViewController에 Transaction RestAPI와 WebsocketAPI를 사용하여 실시간 데잍를 보여주도록 구현하였습니다.
 
**아직 디자인은 적용하지 않은 상태이며 추후 적용 예정입니다.**

### 구현이미지
<div align=center><img src="https://user-images.githubusercontent.com/64210324/156889954-4df898c5-d3d8-414d-8832-7244760be9c5.png" width="300" height="600"></div>

### Related Issue
https://github.com/Bithumb-Tech-Camp/Bithumb-Project/issues/9